### PR TITLE
feat: add stop download file method

### DIFF
--- a/lib/src/ftpconnect_base.dart
+++ b/lib/src/ftpconnect_base.dart
@@ -13,6 +13,7 @@ class FTPConnect {
   final String _user;
   final String _pass;
   late FTPSocket _socket;
+  FTPFile? _downloadFtpFile;
 
   /// Create a FTP Client instance
   ///
@@ -90,8 +91,20 @@ class FTPConnect {
     File fFile, {
     FileProgress? onProgress,
   }) {
-    return FTPFile(_socket)
+    _downloadFtpFile = FTPFile(_socket);
+
+    return _downloadFtpFile!
         .download(sRemoteName, fFile, onProgress: onProgress);
+  }
+
+  /// Stop currently running download
+  Future<bool> stopDownloadFile() async {
+    if (_downloadFtpFile == null) {
+      return false;
+    }
+
+    return _downloadFtpFile!
+        .stopDownload();
   }
 
   /// Create a new Directory with the Name of [sDirectory] in the current directory.


### PR DESCRIPTION
Awesome package and a lifesafer for my project!

Added two basic methods to stop the currently running download, as stated in https://github.com/salim-lachdhaf/dartFTP/issues/31.

Added a subscriber on class scope, which can be canceled. Additionally added the currently downloaded file on class scope, so it can be referenced from the `stopDownloadFile` method.

AFAIK there is on way for multiple async calls to the host? If so, this implementation might not work. Also a `stopUploadFile` method should be implemented for completion.

Hope it helps!