### PR TITLE
fix: parse negative file sizes and fix for FTP 425 error on data connection

### DIFF
--- a/lib/src/commands/directory.dart
+++ b/lib/src/commands/directory.dart
@@ -49,13 +49,14 @@ class FTPDirectory {
     // Enter passive mode
     FTPReply response = await _socket.openDataTransferChannel();
 
-    // Directoy content listing, the response will be handled by another socket
-    _socket.sendCommandWithoutWaitingResponse(_socket.listCommand.describeEnum);
-
     // Data transfer socket
     int iPort = Utils.parsePort(response.message, _socket.supportIPV6);
     Socket dataSocket = await Socket.connect(_socket.host, iPort,
         timeout: Duration(seconds: _socket.timeout));
+
+    // Directoy content listing, the response will be handled by another socket
+    _socket.sendCommandWithoutWaitingResponse(_socket.listCommand.describeEnum);
+
     //Test if second socket connection accepted or not
     response = await _socket.readResponse();
     //some server return two lines 125 and 226 for transfer finished

--- a/lib/src/commands/file.dart
+++ b/lib/src/commands/file.dart
@@ -71,14 +71,15 @@ class FTPFile {
     // Enter passive mode
     FTPReply response = await _socket.openDataTransferChannel();
 
-    //the response will be the file, witch will be loaded with another socket
-    _socket.sendCommandWithoutWaitingResponse('RETR $sRemoteName');
-
     // Data Transfer Socket
     int lPort = Utils.parsePort(response.message, _socket.supportIPV6);
     _socket.logger.log('Opening DataSocket to Port $lPort');
     final Socket dataSocket = await Socket.connect(_socket.host, lPort,
         timeout: Duration(seconds: _socket.timeout));
+
+    // The response will be the file, which will be loaded with another socket
+    _socket.sendCommandWithoutWaitingResponse('RETR $sRemoteName');
+
     // Test if second socket connection accepted or not
     response = await _socket.readResponse();
     //some server return two lines 125 and 226 for transfer finished
@@ -136,13 +137,14 @@ class FTPFile {
       sFilename = basename(fFile.path);
     }
 
-    // The response is the file to upload, witch will be managed by another socket
-    _socket.sendCommandWithoutWaitingResponse('STOR $sFilename');
-
     // Data Transfer Socket
     int iPort = Utils.parsePort(response.message, _socket.supportIPV6);
     _socket.logger.log('Opening DataSocket to Port $iPort');
     final Socket dataSocket = await Socket.connect(_socket.host, iPort);
+
+    // The response is the file to upload, witch will be managed by another socket
+    _socket.sendCommandWithoutWaitingResponse('STOR $sFilename');
+
     //Test if second socket connection accepted or not
     response = await _socket.readResponse();
     //some server return two lines 125 and 226 for transfer finished

--- a/lib/src/ftp_entry.dart
+++ b/lib/src/ftp_entry.dart
@@ -22,7 +22,7 @@ class FTPEntry {
       r"(\d+)\s+" // Number of items [3]
       r"(\w+)\s+" // File owner [4]
       r"(\w+)\s+" // File group [5]
-      r"(\d+)\s+" // File size in bytes [6]
+      r"(\-?\d+)\s+" // File size in bytes [6]
       r"(\w{3}\s+\d{1,2}\s+(?:\d{1,2}:\d{1,2}|\d{4}))\s+" // date[7]
       r"(.+)$" //file/dir name[8]
       );


### PR DESCRIPTION
This pull request addresses two specific issues related to FTP server interactions:

1. **File Size Parsing Issue:** 
   - Some FTP servers return a file size of `(-1)` for certain files, which was not properly handled by the existing code.
   - The parsing regex has been updated to correctly interpret these negative file sizes, ensuring that such files are processed without errors.

2. **FTP 425 Error on Data Connection:**
   - The FTP 425 error occurs when the server fails to establish a data connection. After the `PSV` command, certain FTP servers require that the data connection is opened before any other commands are executed.
   - The `directoryContent`, `download`, and `upload` commands have been modified to respect this requirement. Now, these commands ensure that the data connection is properly established before proceeding, which prevents the FTP 425 error.
