### PR TITLE
Removes version constraints for dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
   sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
-  path: ^1.9.0
-  intl: ^0.19.0
+  path: 
+  intl:
 
 dev_dependencies:
   test: ^1.25.2


### PR DESCRIPTION
Removes the version constraints for the `path` and `intl` dependencies.
