### PR TITLE
Fix data connections over FTPS/FTPES

### DIFF
--- a/lib/src/commands/directory.dart
+++ b/lib/src/commands/directory.dart
@@ -55,8 +55,15 @@ class FTPDirectory {
 
     // Data transfer socket
     int iPort = Utils.parsePort(response.message, _socket.supportIPV6);
-    Socket dataSocket = await Socket.connect(_socket.host, iPort,
-        timeout: Duration(seconds: _socket.timeout));
+    Socket dataSocket = _socket.securityType == SecurityType.ftp
+        ? await Socket.connect(_socket.host, iPort,
+            timeout: Duration(seconds: _socket.timeout))
+        : await SecureSocket.connect(
+            _socket.host,
+            iPort,
+            timeout: Duration(seconds: _socket.timeout),
+            onBadCertificate: (certificate) => true,
+          );
     //Test if second socket connection accepted or not
     response = await _socket.readResponse();
     //some server return two lines 125 and 226 for transfer finished
@@ -70,7 +77,7 @@ class FTPDirectory {
       lstDirectoryListing.addAll(data);
     }).asFuture();
 
-    await dataSocket.close();
+    dataSocket.destroy();
 
     if (!isTransferCompleted) {
       response = await _socket.readResponse();

--- a/lib/src/commands/file.dart
+++ b/lib/src/commands/file.dart
@@ -77,8 +77,15 @@ class FTPFile {
     // Data Transfer Socket
     int lPort = Utils.parsePort(response.message, _socket.supportIPV6);
     _socket.logger.log('Opening DataSocket to Port $lPort');
-    final Socket dataSocket = await Socket.connect(_socket.host, lPort,
-        timeout: Duration(seconds: _socket.timeout));
+    final Socket dataSocket = _socket.securityType == SecurityType.ftp
+        ? await Socket.connect(_socket.host, lPort,
+            timeout: Duration(seconds: _socket.timeout))
+        : await SecureSocket.connect(
+            _socket.host,
+            lPort,
+            timeout: Duration(seconds: _socket.timeout),
+            onBadCertificate: (certificate) => true,
+          );
     // Test if second socket connection accepted or not
     response = await _socket.readResponse();
     //some server return two lines 125 and 226 for transfer finished
@@ -103,7 +110,7 @@ class FTPFile {
       }
     }).asFuture();
 
-    await dataSocket.close();
+    dataSocket.destroy();
     await sink.flush();
     await sink.close();
 
@@ -142,7 +149,15 @@ class FTPFile {
     // Data Transfer Socket
     int iPort = Utils.parsePort(response.message, _socket.supportIPV6);
     _socket.logger.log('Opening DataSocket to Port $iPort');
-    final Socket dataSocket = await Socket.connect(_socket.host, iPort);
+    final Socket dataSocket = _socket.securityType == SecurityType.ftp
+        ? await Socket.connect(_socket.host, iPort,
+            timeout: Duration(seconds: _socket.timeout))
+        : await SecureSocket.connect(
+            _socket.host,
+            iPort,
+            timeout: Duration(seconds: _socket.timeout),
+            onBadCertificate: (certificate) => true,
+          );
     //Test if second socket connection accepted or not
     response = await _socket.readResponse();
     //some server return two lines 125 and 226 for transfer finished
@@ -174,7 +189,7 @@ class FTPFile {
 
     await dataSocket.addStream(readStream);
     await dataSocket.flush();
-    await dataSocket.close();
+    dataSocket.destroy();
 
     if (!isTransferCompleted) {
       // Test if All data are well transferred


### PR DESCRIPTION
As @ChaseGuru mentioned in [#19](https://github.com/salim-lachdhaf/dartFTP/pull/19#issuecomment-1579611192), support for FTPS/FTPES is currently still broken because the client always uses an unencrypted data connection, even when an encrypted connection is required.

This patch fixes this issue by using a SecureSocket for data transfers over FTPS/FTPES.
